### PR TITLE
Problem matcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,17 @@
                 "scopeName": "source.wiz",
                 "path": "./syntaxes/wiz.tmLanguage"
             }
-        ]
+        ],
+        "problemMatcher": {
+            "owner": "wiz",
+            "fileLocation": ["absolute"],
+            "pattern": [{
+                "regexp": "^(.*?):(\\d*):\\s+(error|note):\\s+(.*)$",
+                "file": 1,
+                "line": 2,
+                "severity": 3,
+                "message": 4
+            }]
+        }
     }
 }


### PR DESCRIPTION
Adds problem matcher. It only captures the first message of the error/note, unfortunately it's not possible right now and the feature is in the backlog.
https://github.com/microsoft/vscode/issues/112686

This feature depends on this wiz Pull request: https://github.com/wiz-lang/wiz/pull/135

Working example:
![image](https://user-images.githubusercontent.com/4127660/131072415-380305b4-6e4b-4521-9958-fe471cca132d.png)
